### PR TITLE
Finish up analytics endpoint

### DIFF
--- a/MoneyMind API - Bruno Collection/[02] Analytics/Get Smart Analytics.bru
+++ b/MoneyMind API - Bruno Collection/[02] Analytics/Get Smart Analytics.bru
@@ -1,0 +1,155 @@
+meta {
+  name: Get Smart Analytics
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}{{apiPath}}/analytics?period=90d
+  body: none
+  auth: none
+}
+
+params:query {
+  period: 90d
+}
+
+docs {
+  ## **GET /api/analytics**
+  **Get spending analytics with Malaysian insights and category breakdowns**
+  
+  ### Bruno Configuration:
+  - **Method:** GET
+  - **URL:** `{{baseUrl}}{{apiPath}}/analytics`
+  - **Query Parameters (Optional):**
+    - `period`: Time period for analytics (default: "30d")
+    - Valid values: "7d", "30d", "90d", "1y"
+    - `userId`: User identifier (default: "demo-user-malaysia")
+  
+  ### Expected Response:
+  ```json
+  {
+    "success": true,
+    "data": {
+      "analytics": {
+        "totalSpent": 5750,
+        "totalSpentMYR": "RM 57.50",
+        "transactionCount": 2,
+        "budgetRemaining": 44250,
+        "budgetRemainingMYR": "RM 442.50",
+        "budgetUsagePercentage": 12,
+        "dailyAverage": 192,
+        "dailyAverageMYR": "RM 1.92",
+        "categoryBreakdown": [
+          {
+            "name": "other_miscellaneous",
+            "total": 4500,
+            "count": 1,
+            "percentage": 78,
+            "avgPerTransaction": 4500,
+            "totalMYR": "RM 45.00",
+            "avgPerTransactionMYR": "RM 45.00"
+          },
+          {
+            "name": "food_mamak",
+            "total": 1250,
+            "count": 1,
+            "percentage": 22,
+            "avgPerTransaction": 1250,
+            "totalMYR": "RM 12.50",
+            "avgPerTransactionMYR": "RM 12.50"
+          }
+        ],
+        "spendingTrends": {
+          "dailySpending": [
+            {
+              "date": "2025-08-07",
+              "amount": 5750,
+              "amountMYR": "RM 57.50"
+            }
+          ],
+          "peakSpendingDay": {
+            "date": "2025-08-07",
+            "amount": 5750,
+            "amountMYR": "RM 57.50"
+          },
+          "lowestSpendingDay": {
+            "date": "2025-08-07",
+            "amount": 5750,
+            "amountMYR": "RM 57.50"
+          }
+        },
+        "smartInsights": [
+          "📊 Your top spending category is other miscellaneous at 78%",
+          "✅ Great budgeting! Only 12% of budget used",
+          "🔍 1 transactions need category review"
+        ],
+        "topMerchants": [
+          {
+            "merchant": "KFC",
+            "total": 4500,
+            "totalMYR": "RM 45.00"
+          },
+          {
+            "merchant": "Pelita Nasi Kandar",
+            "total": 1250,
+            "totalMYR": "RM 12.50"
+          }
+        ]
+      },
+      "period": "30d",
+      "dateRange": {
+        "startDate": "2025-07-08",
+        "endDate": "2025-08-07"
+      }
+    },
+    "message": "Analytics calculated for 2 expenses"
+  }
+  ```
+  
+  ### Error Response (400 - Bad Request):
+  ```json
+  {
+    "success": false,
+    "error": "Invalid period. Use one of: 7d, 30d, 90d, 1y"
+  }
+  ```
+  
+  ### Error Response (500 - Server Error):
+  ```json
+  {
+    "success": false,
+    "error": "Failed to get analytics"
+  }
+  ```
+  
+  ### Bruno Documentation:
+  ```markdown
+  **Optional Query Parameters:**
+  - `period`: Analytics time period
+    - "7d" = Last 7 days
+    - "30d" = Last 30 days (default)
+    - "90d" = Last 90 days
+    - "1y" = Last year
+  - `userId`: For testing different users (MVP uses demo-user-malaysia)
+  
+  **Response Fields Explained:**
+  - `totalSpent`: Total amount in cents (5750 = RM 57.50)
+  - `budgetUsagePercentage`: Percentage of RM 500 budget used
+  - `categoryBreakdown`: Expenses grouped by category with percentages
+  - `spendingTrends`: Daily spending data for charts
+  - `smartInsights`: Malaysian-specific spending insights
+  - `topMerchants`: Most frequently used merchants
+  
+  **Malaysian Features:**
+  - All amounts shown in both cents and "RM X.XX" format
+  - Malaysian-specific insights (mamak, transport, e-wallets)
+  - Budget tracking against RM 500 default budget
+  - Smart categorization confidence scoring
+  
+  **Performance Notes:**
+  - Filters expenses by date range in application memory
+  - Efficient for personal finance app scale (< 1000 expenses) - its MVP based anyway
+  - Real-time calculation, no cached data
+  ```
+}

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -105,14 +105,14 @@ functions:
           method: post
           cors: true
 
-  # TODO: Analytics endpoint for dashboard
-  # getAnalytics:
-  #   handler: src/handler/analytics.getAnalytics
-  #   events:
-  #     - http:
-  #         path: /api/analytics
-  #         method: get
-  #         cors: true
+  # Analytics endpoint for dashboard
+  getAnalytics:
+    handler: src/handler/analytics.getAnalytics
+    events:
+      - http:
+          path: /api/analytics
+          method: get
+          cors: true
 
   # OPTIONS handler for CORS preflight
   options:

--- a/backend/src/handler/analytics.ts
+++ b/backend/src/handler/analytics.ts
@@ -1,0 +1,333 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { expenseRepository } from '../service/expense-repository';
+import { APIResponse } from '../types';
+
+export const getAnalytics = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  try {
+    const userId = getUserId(event);
+    const period = event.queryStringParameters?.period || '30d';
+
+    console.log(`Getting analytics for user: ${userId}, period: ${period}`);
+
+    const validPeriods = ['7d', '30d', '90d', '1y'];
+    if (!validPeriods.includes(period)) {
+      return createResponse(400, {
+        success: false,
+        error: `Invalid period. Use one of: ${validPeriods.join(', ')}`,
+      });
+    }
+
+    const dateRange = getDateRange(period);
+    console.log(`Date range: ${dateRange.startDate} to ${dateRange.endDate}`);
+
+    const result = await expenseRepository.getExpenses({
+      userId,
+      limit: 1000, //** Get all expenses, we'll filter in memory. Well, not good practice but this will do for MVP
+    });
+
+    console.log(`Found ${result.items.length} total expenses`);
+
+    //** Filter by date range in memory
+    const filteredExpenses = result.items.filter((expense) => {
+      const expenseDate = expense.date;
+      return expenseDate >= dateRange.startDate && expenseDate <= dateRange.endDate;
+    });
+
+    console.log(
+      `${filteredExpenses.length} expenses in date range ${dateRange.startDate} to ${dateRange.endDate}`
+    );
+
+    const analytics = calculateAnalytics(filteredExpenses, period);
+
+    return createResponse(200, {
+      success: true,
+      data: {
+        analytics,
+        period,
+        dateRange: {
+          startDate: dateRange.startDate,
+          endDate: dateRange.endDate,
+        },
+      },
+      message: `Analytics calculated for ${filteredExpenses.length} expenses`,
+    });
+  } catch (error) {
+    console.error('Error getting analytics:', error);
+    return createResponse(500, {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to get analytics',
+    });
+  }
+};
+
+//** ========================================
+//** UTILITY FUNCTIONS
+//** ========================================
+
+const createResponse = (statusCode: number, body: APIResponse): APIGatewayProxyResult => ({
+  statusCode,
+  headers: {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type,X-Amz-Date,Authorization,X-Api-Key',
+    'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+  },
+  body: JSON.stringify(body, null, 2),
+});
+
+const getUserId = (event: APIGatewayProxyEvent): string => {
+  return event.queryStringParameters?.userId || 'demo-user-malaysia';
+};
+
+//** ========================================
+//** ANALYTICS CALCULATION FUNCTIONS
+//** ========================================
+
+function getDateRange(period: string): { startDate: string; endDate: string } {
+  const endDate = new Date();
+  const startDate = new Date();
+
+  switch (period) {
+    case '7d':
+      startDate.setDate(endDate.getDate() - 7);
+      break;
+    case '30d':
+      startDate.setDate(endDate.getDate() - 30);
+      break;
+    case '90d':
+      startDate.setDate(endDate.getDate() - 90);
+      break;
+    case '1y':
+      startDate.setFullYear(endDate.getFullYear() - 1);
+      break;
+    default:
+      startDate.setDate(endDate.getDate() - 30);
+  }
+
+  return {
+    startDate: startDate.toISOString().split('T')[0], //** YYYY-MM-DD format
+    endDate: endDate.toISOString().split('T')[0],
+  };
+}
+
+function calculateAnalytics(expenses: any[], period: string) {
+  const totalSpent = calculateTotalSpent(expenses);
+  const categoryBreakdown = calculateCategoryBreakdown(expenses);
+  const spendingTrends = calculateSpendingTrends(expenses);
+  const smartInsights = generateSmartInsights(expenses, period);
+
+  return {
+    //** Basic Stats
+    totalSpent: totalSpent,
+    totalSpentMYR: formatMalaysianCurrency(totalSpent),
+    transactionCount: expenses.length,
+    budgetRemaining: 50000, //** RM 500 hardcoded budget for MVP
+    budgetRemainingMYR: formatMalaysianCurrency(50000 - totalSpent),
+    budgetUsagePercentage: totalSpent > 0 ? Math.round((totalSpent / 50000) * 100) : 0,
+
+    //** Average spending
+    dailyAverage: expenses.length > 0 ? Math.round(totalSpent / getDaysInPeriod(period)) : 0,
+    dailyAverageMYR: formatMalaysianCurrency(
+      expenses.length > 0 ? Math.round(totalSpent / getDaysInPeriod(period)) : 0
+    ),
+
+    //** Category Breakdown
+    categoryBreakdown,
+
+    //** Spending Trends
+    spendingTrends,
+
+    //** Malaysian Smart Insights
+    smartInsights,
+
+    //** Top merchants
+    topMerchants: getTopMerchants(expenses),
+  };
+}
+
+function calculateTotalSpent(expenses: any[]): number {
+  return expenses.reduce((total, expense) => total + expense.amount, 0);
+}
+
+function calculateCategoryBreakdown(expenses: any[]) {
+  if (expenses.length === 0) return [];
+
+  const categoryTotals = expenses.reduce((acc, expense) => {
+    const category = expense.category || 'other_miscellaneous';
+    if (!acc[category]) {
+      acc[category] = {
+        name: category,
+        total: 0,
+        count: 0,
+        percentage: 0,
+        avgPerTransaction: 0,
+      };
+    }
+    acc[category].total += expense.amount;
+    acc[category].count += 1;
+    return acc;
+  }, {});
+
+  const totalSpent = calculateTotalSpent(expenses);
+
+  const categories = Object.values(categoryTotals).map((category: any) => ({
+    ...category,
+    totalMYR: formatMalaysianCurrency(category.total),
+    percentage: totalSpent > 0 ? Math.round((category.total / totalSpent) * 100) : 0,
+    avgPerTransaction: Math.round(category.total / category.count),
+    avgPerTransactionMYR: formatMalaysianCurrency(Math.round(category.total / category.count)),
+  }));
+
+  return categories.sort((a, b) => b.total - a.total);
+}
+
+function calculateSpendingTrends(expenses: any[]) {
+  if (expenses.length === 0) {
+    return {
+      dailySpending: [],
+      peakSpendingDay: null,
+      lowestSpendingDay: null,
+    };
+  }
+
+  const dailySpending = expenses.reduce((acc, expense) => {
+    const date = expense.date;
+    acc[date] = (acc[date] || 0) + expense.amount;
+    return acc;
+  }, {});
+
+  const trendData = Object.entries(dailySpending)
+    .map(([date, amount]) => ({
+      date,
+      amount: amount as number,
+      amountMYR: formatMalaysianCurrency(amount as number),
+    }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  if (trendData.length === 0) {
+    return {
+      dailySpending: [],
+      peakSpendingDay: null,
+      lowestSpendingDay: null,
+    };
+  }
+
+  return {
+    dailySpending: trendData,
+    peakSpendingDay: trendData.reduce(
+      (max, day) => (day.amount > max.amount ? day : max),
+      trendData[0]
+    ),
+    lowestSpendingDay: trendData.reduce(
+      (min, day) => (day.amount < min.amount ? day : min),
+      trendData[0]
+    ),
+  };
+}
+
+function generateSmartInsights(expenses: any[], period: string): string[] {
+  const insights: string[] = [];
+
+  if (expenses.length === 0) {
+    insights.push('📊 No expenses found for this period');
+    return insights;
+  }
+
+  const categoryBreakdown = calculateCategoryBreakdown(expenses);
+  const totalSpent = calculateTotalSpent(expenses);
+
+  if (categoryBreakdown.length > 0) {
+    const topCategory = categoryBreakdown[0];
+
+    if (topCategory.name === 'food_mamak') {
+      insights.push(`🍛 Mamak is your top expense at ${topCategory.percentage}% of spending`);
+      insights.push(
+        `💡 You spent ${topCategory.totalMYR} on mamak food - that's ${topCategory.count} visits!`
+      );
+    } else if (topCategory.name.startsWith('food_')) {
+      insights.push(
+        `🍽️ ${topCategory.name.replace('food_', '').replace('_', ' ')} makes up ${topCategory.percentage}% of your spending`
+      );
+    } else {
+      insights.push(
+        `📊 Your top spending category is ${topCategory.name.replace('_', ' ')} at ${topCategory.percentage}%`
+      );
+    }
+  }
+
+  //** Transport insights
+  const transportExpenses = expenses.filter(
+    (exp) =>
+      exp.category?.includes('transport') ||
+      exp.description?.toLowerCase().includes('grab') ||
+      exp.description?.toLowerCase().includes('touch')
+  );
+
+  if (transportExpenses.length > 0) {
+    const transportTotal = transportExpenses.reduce((sum, exp) => sum + exp.amount, 0);
+    insights.push(
+      `🚗 Transport expenses: ${formatMalaysianCurrency(transportTotal)} (${transportExpenses.length} transactions)`
+    );
+  }
+
+  //** Budget insights
+  if (totalSpent > 0) {
+    const budgetUsed = (totalSpent / 50000) * 100;
+    if (budgetUsed > 80) {
+      insights.push(`⚠️ You've used ${Math.round(budgetUsed)}% of your RM 500 budget`);
+    } else if (budgetUsed > 50) {
+      insights.push(
+        `💰 You've used ${Math.round(budgetUsed)}% of your budget - still within limits`
+      );
+    } else {
+      insights.push(`✅ Great budgeting! Only ${Math.round(budgetUsed)}% of budget used`);
+    }
+  }
+
+  //** Confidence insights
+  const lowConfidenceExpenses = expenses.filter((exp) => exp.confidence && exp.confidence < 60);
+  if (lowConfidenceExpenses.length > 0) {
+    insights.push(`🔍 ${lowConfidenceExpenses.length} transactions need category review`);
+  }
+
+  return insights.slice(0, 4);
+}
+
+function getTopMerchants(expenses: any[]) {
+  if (expenses.length === 0) return [];
+
+  const merchantTotals = expenses.reduce((acc, expense) => {
+    const merchant = expense.merchant || 'Unknown';
+    acc[merchant] = (acc[merchant] || 0) + expense.amount;
+    return acc;
+  }, {});
+
+  return Object.entries(merchantTotals)
+    .map(([merchant, total]) => ({
+      merchant,
+      total: total as number,
+      totalMYR: formatMalaysianCurrency(total as number),
+    }))
+    .sort((a, b) => b.total - a.total)
+    .slice(0, 5);
+}
+
+function getDaysInPeriod(period: string): number {
+  switch (period) {
+    case '7d':
+      return 7;
+    case '30d':
+      return 30;
+    case '90d':
+      return 90;
+    case '1y':
+      return 365;
+    default:
+      return 30;
+  }
+}
+
+function formatMalaysianCurrency(cents: number): string {
+  const ringgit = cents / 100;
+  return `RM ${ringgit.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',')}`;
+}


### PR DESCRIPTION
**Resolves/Setup:** Finish up analytics endpoint[#5](https://github.com/mimmydev/moneymind/issues/5)

This pull request addresses
- implement real analytics endpoint based on expenses

## How to Test

1.  Navigate to the `backend` directory.
2.  Run `bun install` to install the new dependencies.
3.  Run `bunx serverless deploy` to deploy the changes.
4.  Use the Bruno collection to test the following endpoints:
    *   `GET /analytics?period=90d`

<img width="3600" height="2312" alt="image" src="https://github.com/user-attachments/assets/74d3853d-4aa1-48fc-9236-316f319ccb20" />

## Notes
Current implementation core is always stick to the MVP criteria we plan beside we just plan use one user as demo, no multiple users in this mini fun project

What could be better?
- instead of doing `Memory Filtering` we can implement `Database Filtering` though if this app has thousand of users then yes
- to add on according to DynamoDB docs for [Read capacity unit](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/CheatSheet.html) it mentioned that
> RCU – One strongly consistent read per second, or two eventually consistent reads per second, for items up to 4 KB in size

so if 2 expenses ≈ reading 2 small items = 1 RCU

that small doesnt really matter, but it does when reading thousands i will eat grass next week

