### PR TITLE
Fix/25 crd actions on fe

### DIFF
--- a/frontend/web/app/components/expenses/ExpenseDataTable.vue
+++ b/frontend/web/app/components/expenses/ExpenseDataTable.vue
@@ -226,6 +226,7 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits<{
   upload: [];
   rowClick: [expense: Expense];
+  editExpense: [expense: Expense];
   deleteExpense: [expense: Expense];
 }>();
 
@@ -312,7 +313,7 @@ const table = useVueTable({
   },
   meta: {
     onViewExpense: (expense: Expense) => emit('rowClick', expense),
-    onEditExpense: (expense: Expense) => emit('rowClick', expense),
+    onEditExpense: (expense: Expense) => emit('editExpense', expense),
     onDeleteExpense: (expense: Expense) => emit('deleteExpense', expense),
   },
   state: {

--- a/frontend/web/app/components/expenses/ExpenseDeleteDialog.vue
+++ b/frontend/web/app/components/expenses/ExpenseDeleteDialog.vue
@@ -39,20 +39,7 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 import { Loader2 } from 'lucide-vue-next';
-
-interface Expense {
-  id: string;
-  description: string;
-  amount: number;
-  amountMYR: string;
-  category: string;
-  date: string;
-  merchant: string;
-  paymentMethod: string;
-  location?: string;
-  createdAt: string;
-  updatedAt: string;
-}
+import type { Expense } from '@/app/services/expenses';
 
 interface Props {
   open: boolean;
@@ -87,7 +74,16 @@ async function handleDelete() {
 }
 
 function formatDate(dateString: string): string {
-  return new Date(dateString).toLocaleDateString('en-MY', {
+  if (!dateString || dateString === 'null' || dateString === 'undefined') {
+    return 'Invalid Date';
+  }
+
+  const date = new Date(dateString);
+  if (isNaN(date.getTime())) {
+    return 'Invalid Date';
+  }
+
+  return date.toLocaleDateString('en-MY', {
     year: 'numeric',
     month: 'short',
     day: 'numeric',

--- a/frontend/web/app/components/expenses/ExpenseEditModal.vue
+++ b/frontend/web/app/components/expenses/ExpenseEditModal.vue
@@ -90,12 +90,15 @@ import { Loader2 } from 'lucide-vue-next';
 interface Expense {
   id: string;
   description: string;
+  description_lowercase: string;
+  userId: string;
   amount: number;
   amountMYR: string;
   category: string;
   date: string;
   merchant: string;
   paymentMethod: string;
+  confidence: number;
   location?: string;
   createdAt: string;
   updatedAt: string;
@@ -129,8 +132,15 @@ watch(
   () => props.expense,
   (expense) => {
     if (expense) {
+      // Handle invalid or missing dates
+      let formattedDate = '';
+      if (expense.date && expense.date !== 'null' && expense.date !== 'undefined') {
+        // If date contains 'T', extract the date part; otherwise use as-is
+        formattedDate = expense.date.includes('T') ? expense.date.split('T')[0] : expense.date;
+      }
+
       formData.value = {
-        date: expense.date.split('T')[0], //** Convert to YYYY-MM-DD format
+        date: formattedDate, //** Convert to YYYY-MM-DD format with validation
         amount: expense.amount / 100, //** Convert from cents to RM
         description: expense.description,
         merchant: expense.merchant,

--- a/frontend/web/app/components/expenses/ExpenseEditModal.vue
+++ b/frontend/web/app/components/expenses/ExpenseEditModal.vue
@@ -14,7 +14,7 @@
           </div>
           <div class="grid gap-2">
             <Label for="amount">Amount (RM)</Label>
-            <Input id="amount" type="number" step="0.01" v-model="formData.amount" required />
+            <Input id="amount" type="number" step="0.01" v-model="amountForDisplay" required />
           </div>
         </div>
 
@@ -73,9 +73,9 @@
           <Button type="button" variant="outline" @click="$emit('update:open', false)">
             Cancel
           </Button>
-          <Button type="submit" :disabled="isSaving">
-            <Loader2 v-if="isSaving" class="mr-2 h-4 w-4 animate-spin" />
-            {{ isSaving ? 'Saving...' : 'Save Changes' }}
+          <Button type="submit" :disabled="props.isSaving">
+            <Loader2 v-if="props.isSaving" class="mr-2 h-4 w-4 animate-spin" />
+            {{ props.isSaving ? 'Saving...' : 'Save Changes' }}
           </Button>
         </DialogFooter>
       </form>
@@ -84,7 +84,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue';
+import { ref, watch, computed } from 'vue';
 import { Loader2 } from 'lucide-vue-next';
 
 interface Expense {
@@ -107,6 +107,7 @@ interface Expense {
 interface Props {
   open: boolean;
   expense: Expense | null;
+  isSaving?: boolean;
 }
 
 const props = defineProps<Props>();
@@ -116,7 +117,6 @@ const emit = defineEmits<{
   save: [expense: Expense];
 }>();
 
-const isSaving = ref(false);
 const formData = ref({
   date: '',
   amount: 0,
@@ -125,6 +125,15 @@ const formData = ref({
   category: '',
   paymentMethod: '',
   location: '',
+});
+
+//** Computed property for amount display with proper decimal formatting
+const amountForDisplay = computed({
+  get: () => formData.value.amount.toFixed(2),
+  set: (value: string) => {
+    const numericValue = parseFloat(value) || 0;
+    formData.value.amount = numericValue;
+  },
 });
 
 //** Watch for expense changes to populate form
@@ -156,31 +165,20 @@ watch(
 async function handleSubmit() {
   if (!props.expense) return;
 
-  try {
-    isSaving.value = true;
+  const updatedExpense: Expense = {
+    ...props.expense,
+    date: formData.value.date,
+    amount: Math.round(formData.value.amount * 100), //** Convert to cents
+    amountMYR: `RM ${formData.value.amount.toFixed(2)}`,
+    description: formData.value.description,
+    merchant: formData.value.merchant,
+    category: formData.value.category,
+    paymentMethod: formData.value.paymentMethod,
+    location: formData.value.location || undefined,
+    updatedAt: new Date().toISOString(),
+  };
 
-    const updatedExpense: Expense = {
-      ...props.expense,
-      date: formData.value.date,
-      amount: Math.round(formData.value.amount * 100), //** Convert to cents
-      amountMYR: `RM ${formData.value.amount.toFixed(2)}`,
-      description: formData.value.description,
-      merchant: formData.value.merchant,
-      category: formData.value.category,
-      paymentMethod: formData.value.paymentMethod,
-      location: formData.value.location || undefined,
-      updatedAt: new Date().toISOString(),
-    };
-
-    //** Simulate API call delay
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-
-    emit('save', updatedExpense);
-    emit('update:open', false);
-  } catch (error) {
-    console.error('Failed to save expense:', error);
-  } finally {
-    isSaving.value = false;
-  }
+  //** Emit the save event - let the parent composable handle the API call
+  emit('save', updatedExpense);
 }
 </script>

--- a/frontend/web/app/components/expenses/ExpenseRowActions.vue
+++ b/frontend/web/app/components/expenses/ExpenseRowActions.vue
@@ -1,7 +1,7 @@
 <template>
   <DropdownMenu>
     <DropdownMenuTrigger as-child>
-      <Button variant="ghost" class="h-8 w-8 p-0">
+      <Button variant="ghost" class="h-8 w-8 p-0" @click.stop>
         <span class="sr-only">Open menu</span>
         <MoreHorizontal class="h-4 w-4" />
       </Button>

--- a/frontend/web/app/components/expenses/columns.ts
+++ b/frontend/web/app/components/expenses/columns.ts
@@ -1,9 +1,10 @@
 import type { ColumnDef } from '@tanstack/vue-table';
 import { h } from 'vue';
-import { ArrowUpDown, Eye, Edit, Trash2 } from 'lucide-vue-next';
+import { ArrowUpDown } from 'lucide-vue-next';
 import { Button } from '@/app/components/ui/button';
 import { Badge } from '@/app/components/ui/badge';
-import type { Expense } from '@/services/expenses';
+import ExpenseRowActions from './ExpenseRowActions.vue';
+import type { Expense } from '../../services/expenses';
 
 //** Define proper types for table meta
 interface TableMeta {
@@ -27,7 +28,16 @@ export const columns: ColumnDef<Expense>[] = [
       );
     },
     cell: ({ row }) => {
-      const date = new Date(row.getValue('date'));
+      const dateValue = row.getValue('date') as string;
+      if (!dateValue || dateValue === 'null' || dateValue === 'undefined') {
+        return h('div', { class: 'font-medium text-sm text-muted-foreground' }, 'Invalid Date');
+      }
+
+      const date = new Date(dateValue);
+      if (isNaN(date.getTime())) {
+        return h('div', { class: 'font-medium text-sm text-muted-foreground' }, 'Invalid Date');
+      }
+
       return h(
         'div',
         { class: 'font-medium text-sm' },
@@ -172,63 +182,33 @@ export const columns: ColumnDef<Expense>[] = [
   {
     id: 'actions',
     enableHiding: false,
+    header: () => h('div', { class: 'text-left' }, 'Actions'),
     cell: ({ row, table }) => {
       const expense = row.original;
       const meta = table.options.meta as TableMeta;
 
-      return h('div', { class: 'flex items-center justify-end space-x-1' }, [
-        //** View button
-        h(
-          Button,
-          {
-            variant: 'ghost',
-            size: 'sm',
-            class: 'h-8 w-8 p-0 hover:bg-muted',
-            onClick: (e: Event) => {
-              e.stopPropagation();
-              if (meta?.onViewExpense) {
-                meta.onViewExpense(expense);
-              }
-            },
-            title: 'View details',
+      return h(
+        'div',
+        { class: 'flex items-center justify-end' },
+        h(ExpenseRowActions, {
+          expense,
+          onView: (expense: Expense) => {
+            if (meta?.onViewExpense) {
+              meta.onViewExpense(expense);
+            }
           },
-          () => h(Eye, { class: 'h-4 w-4' })
-        ),
-        //** Edit button
-        h(
-          Button,
-          {
-            variant: 'ghost',
-            size: 'sm',
-            class: 'h-8 w-8 p-0 hover:bg-muted',
-            onClick: (e: Event) => {
-              e.stopPropagation();
-              if (meta?.onEditExpense) {
-                meta.onEditExpense(expense);
-              }
-            },
-            title: 'Edit expense',
+          onEdit: (expense: Expense) => {
+            if (meta?.onEditExpense) {
+              meta.onEditExpense(expense);
+            }
           },
-          () => h(Edit, { class: 'h-4 w-4' })
-        ),
-        //** Delete button
-        h(
-          Button,
-          {
-            variant: 'ghost',
-            size: 'sm',
-            class: 'h-8 w-8 p-0 hover:bg-destructive/10 hover:text-destructive',
-            onClick: (e: Event) => {
-              e.stopPropagation();
-              if (meta?.onDeleteExpense) {
-                meta.onDeleteExpense(expense);
-              }
-            },
-            title: 'Delete expense',
+          onDelete: (expense: Expense) => {
+            if (meta?.onDeleteExpense) {
+              meta.onDeleteExpense(expense);
+            }
           },
-          () => h(Trash2, { class: 'h-4 w-4' })
-        ),
-      ]);
+        })
+      );
     },
   },
 ];

--- a/frontend/web/app/composables/useExpenseManagement.ts
+++ b/frontend/web/app/composables/useExpenseManagement.ts
@@ -25,6 +25,7 @@ export const useExpenseManagement = () => {
   const showEditModal = ref(false);
   const showDeleteDialog = ref(false);
   const selectedExpense = ref<Expense | null>(null);
+  const isSaving = ref(false);
 
   //** Modal handlers
   const handleViewExpense = (expense: Expense) => {
@@ -50,6 +51,9 @@ export const useExpenseManagement = () => {
     }
 
     try {
+      isSaving.value = true;
+      console.log('🔄 handleSaveExpense: Starting expense update...');
+
       const updatedData = await updateExpense(
         updatedExpense.id,
         selectedExpense.value.date,
@@ -61,9 +65,12 @@ export const useExpenseManagement = () => {
       //** Update the store with the response from the API
       await expensesStore.updateExpense(updatedData.id, updatedData);
 
+      console.log('✅ handleSaveExpense: Store updated successfully');
       showEditModal.value = false;
     } catch (error) {
       console.error('❌ handleSaveExpense: Failed to update expense:', error);
+    } finally {
+      isSaving.value = false;
     }
   };
 
@@ -90,6 +97,7 @@ export const useExpenseManagement = () => {
     showEditModal,
     showDeleteDialog,
     selectedExpense,
+    isSaving,
 
     //** Handlers
     handleViewExpense,

--- a/frontend/web/app/composables/useExpenseManagement.ts
+++ b/frontend/web/app/composables/useExpenseManagement.ts
@@ -1,6 +1,6 @@
 import { ref, onMounted, computed } from 'vue';
 import { useExpensesStore } from '../stores/useExpensesStore';
-import { deleteExpense } from '../services/expenses';
+import { deleteExpense, updateExpense } from '../services/expenses';
 import type { Expense } from '../services/expenses';
 
 export const useExpenseManagement = () => {
@@ -44,8 +44,27 @@ export const useExpenseManagement = () => {
   };
 
   const handleSaveExpense = async (updatedExpense: Expense) => {
-    await expensesStore.updateExpense(updatedExpense.id, updatedExpense);
-    showEditModal.value = false;
+    if (!selectedExpense.value) {
+      console.error('No selected expense for update');
+      return;
+    }
+
+    try {
+      const updatedData = await updateExpense(
+        updatedExpense.id,
+        selectedExpense.value.date,
+        updatedExpense
+      );
+
+      console.log('✅ handleSaveExpense: Service call successful, updating store...');
+
+      //** Update the store with the response from the API
+      await expensesStore.updateExpense(updatedData.id, updatedData);
+
+      showEditModal.value = false;
+    } catch (error) {
+      console.error('❌ handleSaveExpense: Failed to update expense:', error);
+    }
   };
 
   const handleDeleteConfirmed = async (expense: Expense) => {
@@ -55,7 +74,6 @@ export const useExpenseManagement = () => {
       showDeleteDialog.value = false;
     } catch (error) {
       console.error('Failed to delete expense:', error);
-      // Keep dialog open on error
     }
   };
 

--- a/frontend/web/app/composables/useExpenseManagement.ts
+++ b/frontend/web/app/composables/useExpenseManagement.ts
@@ -1,5 +1,6 @@
 import { ref, onMounted, computed } from 'vue';
 import { useExpensesStore } from '../stores/useExpensesStore';
+import { deleteExpense } from '../services/expenses';
 import type { Expense } from '../services/expenses';
 
 export const useExpenseManagement = () => {
@@ -48,8 +49,14 @@ export const useExpenseManagement = () => {
   };
 
   const handleDeleteConfirmed = async (expense: Expense) => {
-    await expensesStore.deleteExpense(expense.id);
-    showDeleteDialog.value = false;
+    try {
+      await deleteExpense(expense.id, expense.date);
+      await expensesStore.deleteExpense(expense.id);
+      showDeleteDialog.value = false;
+    } catch (error) {
+      console.error('Failed to delete expense:', error);
+      // Keep dialog open on error
+    }
   };
 
   return {

--- a/frontend/web/app/pages/expenses.vue
+++ b/frontend/web/app/pages/expenses.vue
@@ -7,6 +7,7 @@
         :is-loading="isLoading"
         @upload="handleUpload"
         @row-click="handleViewExpense"
+        @edit-expense="handleEditExpense"
         @delete-expense="handleDeleteExpense"
       />
     </div>
@@ -90,6 +91,7 @@ import ExpenseEditModal from '@/app/components/expenses/ExpenseEditModal.vue';
 import ExpenseDeleteDialog from '@/app/components/expenses/ExpenseDeleteDialog.vue';
 import { useExpenseManagement } from '@/app/composables/useExpenseManagement';
 import { useExpensesStore } from '@/app/stores/useExpensesStore';
+import { uploadExpenses } from '@/app/services/expenses';
 
 //** Use composable for all expense management logic
 const {
@@ -152,21 +154,14 @@ async function uploadFile() {
   try {
     isUploading.value = true;
 
-    const formData = new FormData();
-    formData.append('file', selectedFile.value);
+    //** Upload file using the service
+    const result = await uploadExpenses(selectedFile.value);
 
-    const endpoint = selectedFile.value.name.endsWith('.csv')
-      ? '/api/expenses/csv'
-      : '/api/expenses/bulk';
+    console.log('Upload successful:', result.message);
+    console.log('Summary:', result.data.summary);
 
-    //** TODO: Implement actual upload API call
-    console.log('Uploading file:', selectedFile.value.name, 'to', endpoint);
-
-    //** Simulate upload delay
-    await new Promise((resolve) => setTimeout(resolve, 2000));
-
-    //** Reload expenses after upload
-    await fetchExpenses();
+    //** Force reload expenses after upload to ensure UI refreshes
+    await fetchExpenses(true);
 
     //** Reset upload state
     showUploadDialog.value = false;
@@ -176,6 +171,7 @@ async function uploadFile() {
     }
   } catch (error) {
     console.error('Upload failed:', error);
+    //** TODO: Show user-friendly error message
   } finally {
     isUploading.value = false;
   }

--- a/frontend/web/app/pages/expenses.vue
+++ b/frontend/web/app/pages/expenses.vue
@@ -21,6 +21,7 @@
     <ExpenseEditModal
       v-model:open="showEditModal"
       :expense="selectedExpense"
+      :is-saving="isSaving"
       @save="handleSaveExpense"
     />
 
@@ -103,6 +104,7 @@ const {
   showEditModal,
   showDeleteDialog,
   selectedExpense,
+  isSaving,
   handleViewExpense,
   handleEditExpense,
   handleDeleteExpense,

--- a/frontend/web/app/services/expenses.ts
+++ b/frontend/web/app/services/expenses.ts
@@ -76,3 +76,74 @@ export const getExpensesByPeriod = async (
     return getExpenses();
   }
 };
+
+interface UploadResponse {
+  success: boolean;
+  data: {
+    successful: Expense[];
+    failed: any[];
+    csvProcessing?: {
+      totalRows: number;
+      validExpenses: number;
+      duplicatesSkipped: number;
+    };
+    summary: {
+      totalProcessed: number;
+      successful: number;
+      failed: number;
+      totalAmount: number;
+      totalAmountMYR: string;
+    };
+  };
+  message: string;
+}
+
+export const uploadExpenses = async (file: File): Promise<UploadResponse> => {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  // Determine endpoint based on file type
+  const endpoint = file.name.endsWith('.csv') ? '/expenses/csv' : '/expenses/bulk';
+
+  const response = await apiClient.post<UploadResponse>(endpoint, formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  });
+
+  return response.data;
+};
+
+interface DeleteResponse {
+  success: boolean;
+  message: string;
+}
+
+export const deleteExpense = async (id: string, date: string): Promise<DeleteResponse> => {
+  // Handle null, undefined, or empty dates
+  if (!date || date === 'null' || date === 'undefined') {
+    throw new Error('Date is required for expense deletion');
+  }
+
+  // Format date to YYYY-MM-DD if it's not already in that format
+  let formattedDate = date;
+  if (date.includes('T')) {
+    // If it's an ISO string, extract just the date part
+    const datePart = date.split('T')[0];
+    if (datePart) {
+      formattedDate = datePart;
+    }
+  } else if (!date.match(/^\d{4}-\d{2}-\d{2}$/)) {
+    // If it's not in YYYY-MM-DD format, try to parse and format it
+    const dateObj = new Date(date);
+    if (!isNaN(dateObj.getTime())) {
+      const isoDatePart = dateObj.toISOString().split('T')[0];
+      if (isoDatePart) {
+        formattedDate = isoDatePart;
+      }
+    }
+  }
+
+  const response = await apiClient.delete<DeleteResponse>(`/expenses/${id}?date=${formattedDate}`);
+  return response.data;
+};

--- a/frontend/web/app/services/expenses.ts
+++ b/frontend/web/app/services/expenses.ts
@@ -156,11 +156,8 @@ export const updateExpense = async (
     }
   }
 
-  //** Prepare the update payload, converting amount to cents if provided
+  //** Prepare the update payload (amount is already in cents from the modal)
   const updatePayload: any = { ...updatedExpense };
-  if (updatePayload.amount !== undefined) {
-    updatePayload.amount = Math.round(updatePayload.amount * 100); //** Convert to cents
-  }
 
   //** Remove fields that shouldn't be sent in the update request
   delete updatePayload.id;

--- a/frontend/web/app/stores/useExpensesStore.ts
+++ b/frontend/web/app/stores/useExpensesStore.ts
@@ -17,12 +17,9 @@ export const useExpensesStore = defineStore('expenses', () => {
   //** Actions
   const fetchExpenses = async (force: boolean = false) => {
     try {
-      console.log('🔄 fetchExpenses: Starting to fetch expenses...');
       isLoading.value = true;
       error.value = null;
-      console.log('🔄 fetchExpenses: isLoading set to true');
 
-      console.log('🔄 fetchExpenses: Calling getExpenses()...');
       expenses.value = await getExpenses();
       console.log(
         '✅ fetchExpenses: Successfully fetched expenses:',
@@ -31,17 +28,22 @@ export const useExpensesStore = defineStore('expenses', () => {
       );
     } catch (err) {
       error.value = err instanceof Error ? err.message : 'Failed to fetch expenses';
-      console.error('❌ fetchExpenses: Error fetching expenses:', err);
     } finally {
       isLoading.value = false;
-      console.log('🔄 fetchExpenses: isLoading set to false');
     }
   };
 
   const updateExpense = async (id: string, updates: Partial<Expense>) => {
-    const index = expenses.value.findIndex((e) => e.id === id);
-    if (index !== -1) {
-      expenses.value[index] = { ...expenses.value[index], ...updates } as Expense;
+    try {
+      const index = expenses.value.findIndex((e) => e.id === id);
+      if (index !== -1) {
+        expenses.value[index] = { ...expenses.value[index], ...updates } as Expense;
+      }
+
+      await fetchExpenses();
+    } catch (err) {
+      console.error('❌ updateExpense: Error updating expense:', err);
+      throw err;
     }
   };
 

--- a/frontend/web/app/stores/useExpensesStore.ts
+++ b/frontend/web/app/stores/useExpensesStore.ts
@@ -15,7 +15,7 @@ export const useExpensesStore = defineStore('expenses', () => {
   );
 
   //** Actions
-  const fetchExpenses = async () => {
+  const fetchExpenses = async (force: boolean = false) => {
     try {
       console.log('🔄 fetchExpenses: Starting to fetch expenses...');
       isLoading.value = true;


### PR DESCRIPTION
Resolves/Setup: Finish up analytics endpoint https://github.com/mimmydev/moneymind/issues/25

This pull request addresses:
- Fixed three major expense editing bugs:
  1. **UI Update Issues**: Modal would close but data table wouldn't reflect changes
  2. **Amount Formatting Problems**: Decimal display and cents conversion issues
  3. **Double Conversion Errors**: Massive incorrect values in database
- Fixed an issue where the `/expenses` page would show an empty state on direct load. The fix involved aligning the data fetching pattern with the home page, using `onMounted` for client-side fetching and `computed()` for proper reactivity
- Fixed JavaScript errors ("can't access property 'split', expense.date is undefined") in the expense deletion flow. Updated the delete service to comply with Bruno API specification requiring both expense ID and date parameter, added proper null/undefined date validation throughout the UI, and ensured Actions column visibility in the data table